### PR TITLE
feat: Add like and unlike functionality for posts

### DIFF
--- a/Backend/src/post/post.controller.ts
+++ b/Backend/src/post/post.controller.ts
@@ -116,4 +116,38 @@ export class PostController {
   remove(@Param('id') id: string) {
     return this.postService.remove(+id);
   }
+
+  @UseGuards(AuthGuard)
+  @Post('like/:id')
+  async likePost(@Param('id') postId: string, @Request() req) {
+    if (!req.user) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    const userId = req.user._id;
+
+    try {
+      await this.postService.likePost(userId, postId);
+      return { message: 'Post liked successfully' };
+    } catch (error) {
+      throw new BadRequestException(error.message || 'Failed to like post');
+    }
+  }
+
+  @UseGuards(AuthGuard)
+  @Delete('like/:id')
+  async unlikePost(@Param('id') postId: string, @Request() req) {
+    if (!req.user) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    const userId = req.user._id;
+
+    try {
+      await this.postService.unlikePost(userId, postId);
+      return { message: 'Post unliked successfully' };
+    } catch (error) {
+      throw new BadRequestException(error.message || 'Failed to unlike post');
+    }
+  }
 }

--- a/Backend/src/post/post.service.ts
+++ b/Backend/src/post/post.service.ts
@@ -138,4 +138,58 @@ export class PostService {
     const post = await this.postModel.findOne({ where: { id } });
     await post.deleteOne();
   }
+
+  async likePost(userId: any, postId: string) {
+    try {
+      if (!Types.ObjectId.isValid(postId)) {
+        throw new Error('Invalid post ID format');
+      }
+
+      const post = await this.postModel.findById(postId);
+
+      if (!post) {
+        throw new Error('Post not found');
+      }
+
+      if (post.likes.includes(userId)) {
+        throw new Error('Post already liked by user');
+      }
+
+      post.likes.push(userId);
+
+      await post.save();
+
+      return { message: 'Post liked successfully' };
+    } catch (error) {
+      console.error('Error liking post:', error.message);
+      throw new Error('Could not like post');
+    }
+  }
+
+  async unlikePost(userId: any, postId: string) {
+    try {
+      if (!Types.ObjectId.isValid(postId)) {
+        throw new Error('Invalid post ID format');
+      }
+
+      const post = await this.postModel.findById(postId);
+
+      if (!post) {
+        throw new Error('Post not found');
+      }
+
+      if (!post.likes.includes(userId)) {
+        throw new Error('Post not liked by user');
+      }
+
+      post.likes = post.likes.filter((id) => id !== userId);
+
+      await post.save();
+
+      return { message: 'Post unliked successfully' };
+    } catch (error) {
+      console.error('Error unliking post:', error.message);
+      throw new Error('Could not unlike post');
+    }
+  }
 }


### PR DESCRIPTION
This pull request introduces new functionality to the `PostController` and `PostService` classes to allow users to like and unlike posts. The changes include adding new methods and routes to handle these actions, as well as ensuring proper authentication and error handling.

New functionality for liking and unliking posts:

* [`Backend/src/post/post.controller.ts`](diffhunk://#diff-b58dac26b1b9b52a08034efa61a6cdd040d6ae0d32db1bd2a841f84455c8e6c3R119-R152): Added `likePost` and `unlikePost` methods to handle POST and DELETE requests for liking and unliking posts, respectively. These methods use the `AuthGuard` to ensure the user is authenticated and handle potential errors.
* [`Backend/src/post/post.service.ts`](diffhunk://#diff-a40f19b1284603cdee0b35ab789013b295f9f8afcc7384f63f9b2362b7178f8dR141-R194): Added `likePost` and `unlikePost` methods to manage the logic of liking and unliking posts. These methods validate the post ID, check if the post exists, and handle cases where the post is already liked or not liked by the user.